### PR TITLE
Refactor: Modularize Persistent Volumes and Claims

### DIFF
--- a/deployments.tf
+++ b/deployments.tf
@@ -5,7 +5,7 @@ module "urlradar_deployment" {
   image          = "rblessings/urlradar:latest"
   container_name = "urlradar"
 
-  # TODO: URLradar is currently not stateless-compliant. Refer to README.md for ongoing work in this area.
+  # TODO: URLradar is currently not stateless-compliant. Refer to the README.md for ongoing work in this area.
   #       This constraint restricts demos to a single pod configuration.
   replicas       = 1
   container_port = 8080
@@ -40,7 +40,7 @@ module "urlradar_deployment" {
     {
       name = "SPRING_DATA_MONGODB_URI"
 
-      # TODO: Integrate Vault or Kubernetes Secrets for secure credential retrieval
+      # TODO: Integrate HashiCorp Vault or Kubernetes Secrets for secure credential retrieval.
       value = "mongodb://root:secret@mongodb-svc:27017/urlradar?authSource=admin"
     },
     {
@@ -109,7 +109,7 @@ module "mongodb_statefulset" {
     },
     {
       name  = "MONGO_INITDB_ROOT_PASSWORD"
-      value = "secret" # TODO: Integrate Vault or Kubernetes Secrets for secure credential retrieval
+      value = "secret" # TODO: Integrate HashiCorp Vault or Kubernetes Secrets for secure credential retrieval.
     },
     {
       name  = "MONGO_INITDB_DATABASE"

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -1,27 +1,13 @@
 /*
-  This resource definition demonstrates one method for deploying a workload on a Kubernetes cluster
-  using the Terraform Kubernetes provider.
+  Deploys a workload on Kubernetes using Terraform; suitable for simple workloads.
+  For complex setups, use existing Kubernetes YAML manifests.
 
-  While this approach works well for simple workloads, it is generally recommended to use pre-existing
-  Kubernetes YAML manifests for more complex or production-grade applications. These manifests are often
-  created and maintained by infrastructure teams to ensure consistency and alignment with best practices.
-
-  Example of using a Kubernetes manifest resource:
-
-  provider "kubernetes" {
-    // Configure the Kubernetes provider with the necessary credentials and cluster details
-  }
-
+  Example:
   resource "kubernetes_manifest" "example" {
     provider = kubernetes
     manifest = yamldecode(file("${path.module}/deployment.yaml"))
   }
-
-  This approach allows you to directly apply Kubernetes YAML configuration files, which is particularly
-  useful in environments where manifests are already in use, need to be version-controlled, or must be
-  maintained separately from Terraform configuration.
-*/
-
+ */
 resource "kubernetes_deployment" "this" {
   metadata {
     name = var.name

--- a/modules/pvc/main.tf
+++ b/modules/pvc/main.tf
@@ -1,0 +1,46 @@
+# TODO: The StatefulSet is currently using HostPath volumes for persistent storage.
+#   While this setup works for single-node deployments, it severely limits our ability to scale horizontally across multiple nodes.
+#   For upcoming alternatives, refer to issue #36 at https://github.com/rblessings/terraform/issues/36
+resource "kubernetes_persistent_volume" "this" {
+  metadata {
+    name = var.pv_name
+    labels = merge(var.labels, {
+      type = "hostpath" # Label to ensure PVC binds to the correct PV
+    })
+  }
+
+  spec {
+    capacity = {
+      storage = var.pv_storage
+    }
+
+    access_modes = var.pv_access_modes
+
+    persistent_volume_source {
+      host_path {
+        path = var.pv_path # Ensure this path exists on the node
+      }
+    }
+
+    storage_class_name = var.pv_storage_class
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "this" {
+  metadata {
+    name      = var.pvc_name
+    namespace = var.pvc_namespace
+  }
+
+  spec {
+    resources {
+      requests = {
+        storage = var.pvc_storage
+      }
+    }
+
+    access_modes       = var.pvc_access_modes
+    storage_class_name = var.pvc_storage_class
+    volume_name        = kubernetes_persistent_volume.this.metadata[0].name
+  }
+}

--- a/modules/pvc/outputs.tf
+++ b/modules/pvc/outputs.tf
@@ -1,0 +1,3 @@
+output "pvc_name" {
+  value = kubernetes_persistent_volume_claim.this.metadata[0].name
+}

--- a/modules/pvc/variables.tf
+++ b/modules/pvc/variables.tf
@@ -1,0 +1,63 @@
+variable "pvc_namespace" {
+  type        = string
+  description = "The name of the PVC namespace."
+  default     = "default"
+}
+
+variable "pv_name" {
+  type        = string
+  description = "The name of the PV"
+}
+
+variable "pvc_name" {
+  type        = string
+  description = "The name of the PVC."
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to attach to the PV, PVC, and StatefulSet."
+  default     = {}
+}
+
+variable "pv_storage" {
+  type        = string
+  description = "The storage size for the PersistentVolume."
+  default     = "20Gi"
+}
+
+variable "pv_access_modes" {
+  type        = list(string)
+  description = "The access modes for the PersistentVolume."
+  default     = ["ReadWriteOnce"]
+}
+
+# corresponds to a directory on the node where data will persist
+variable "pv_path" {
+  type        = string
+  description = "The host path for the PersistentVolume."
+}
+
+variable "pv_storage_class" {
+  type        = string
+  description = "The storage class for the PersistentVolume."
+  default     = "slow"
+}
+
+variable "pvc_storage" {
+  type        = string
+  description = "The storage size for the PersistentVolumeClaim."
+  default     = "20Gi"
+}
+
+variable "pvc_access_modes" {
+  type        = list(string)
+  description = "The access modes for the PersistentVolumeClaim."
+  default     = ["ReadWriteOnce"]
+}
+
+variable "pvc_storage_class" {
+  type        = string
+  description = "The storage class for the PersistentVolumeClaim."
+  default     = "slow"
+}

--- a/modules/statefulset/variables.tf
+++ b/modules/statefulset/variables.tf
@@ -9,48 +9,6 @@ variable "labels" {
   default     = {}
 }
 
-variable "pv_storage" {
-  type        = string
-  description = "The storage size for the PersistentVolume."
-  default     = "20Gi"
-}
-
-variable "pv_access_modes" {
-  type        = list(string)
-  description = "The access modes for the PersistentVolume."
-  default     = ["ReadWriteOnce"]
-}
-
-# corresponds to a directory on the node where data will persist
-variable "pv_path" {
-  type        = string
-  description = "The host path for the PersistentVolume."
-}
-
-variable "pv_storage_class" {
-  type        = string
-  description = "The storage class for the PersistentVolume."
-  default     = "slow"
-}
-
-variable "pvc_storage" {
-  type        = string
-  description = "The storage size for the PersistentVolumeClaim."
-  default     = "20Gi"
-}
-
-variable "pvc_access_modes" {
-  type        = list(string)
-  description = "The access modes for the PersistentVolumeClaim."
-  default     = ["ReadWriteOnce"]
-}
-
-variable "pvc_storage_class" {
-  type        = string
-  description = "The storage class for the PersistentVolumeClaim."
-  default     = "slow"
-}
-
 variable "replicas" {
   type        = number
   description = "The number of replicas in the StatefulSet."
@@ -135,4 +93,52 @@ variable "environment" {
 variable "mount_path" {
   type        = string
   description = "The path inside the container where the volume will be mounted."
+}
+
+variable "pv_storage_class" {
+  type        = string
+  description = "The storage class for the PersistentVolume."
+  default     = "slow"
+}
+
+variable "pvc_storage" {
+  type        = string
+  description = "The storage size for the PersistentVolumeClaim."
+  default     = "20Gi"
+}
+
+variable "pvc_access_modes" {
+  type        = list(string)
+  description = "The access modes for the PersistentVolumeClaim."
+  default     = ["ReadWriteOnce"]
+}
+
+variable "pvc_storage_class" {
+  type        = string
+  description = "The storage class for the PersistentVolumeClaim."
+  default     = "slow"
+}
+
+variable "pv_storage" {
+  type        = string
+  description = "The storage size for the PersistentVolume."
+  default     = "20Gi"
+}
+
+variable "pv_access_modes" {
+  type        = list(string)
+  description = "The access modes for the PersistentVolume."
+  default     = ["ReadWriteOnce"]
+}
+
+# corresponds to a directory on the node where data will persist
+variable "pv_path" {
+  type        = string
+  description = "The host path for the PersistentVolume."
+}
+
+variable "pvc_namespace" {
+  type        = string
+  description = "The name of the PVC namespace."
+  default     = "default"
 }


### PR DESCRIPTION
- Created a reusable Terraform module for Persistent Volume (PV) and Persistent Volume Claim (PVC).
- Updated `modules/pvc` with variables and outputs for PV and PVC configurations.
- Refactored statefulSets and monitoring code to use the PVC module.
- Ensured correct binding of PVCs to PVs in Kubernetes.
- Verified PV and PVC configurations in the Kubernetes cluster using `kubectl`.

This refactoring enhances code reusability and maintainability, ensuring consistent volume configuration across different environments.