### PR TITLE
Add setup_directories.sh script for automated directory creation and permission setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ repository: [https://github.com/rblessings/urlradar](https://github.com/rblessin
 
 ---
 
-This repository contains a Terraform project where I am experimenting with advanced features, best practices, and
-setting up a GitHub CI/CD pipeline using GitHub Actions. The goal is to create an infrastructure-as-code (IaC) solution
-that adheres to the latest standards in Terraform and integrates seamlessly with CI/CD workflows. Additionally, the
-project includes comprehensive monitoring of Kubernetes clusters using Prometheus and Grafana, providing real-time
-observability, metrics collection, and visualization, ensuring the scalability and reliability of cloud-native
-infrastructures.
+This repository showcases a Terraform project focused on advanced features, best practices, and a GitHub Actions-based
+CI/CD pipeline. The objective is to implement a modern IaC solution that aligns with Terraform's latest standards and
+integrates with CI/CD workflows. It also includes comprehensive Kubernetes monitoring with Prometheus and Grafana for
+real-time observability, metrics collection, and visualization, ensuring cloud-native infrastructure scalability and
+reliability.
 
 [![Terraform Validation](https://github.com/rblessings/terraform/actions/workflows/terraform.yml/badge.svg)](https://github.com/rblessings/terraform/actions/workflows/terraform.yml)
 [![Dependabot Updates](https://github.com/rblessings/terraform/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/rblessings/terraform/actions/workflows/dependabot/dependabot-updates)
@@ -61,7 +60,54 @@ Before using this repository, ensure that the following software is installed:
 
 ## Usage
 
-### Running Terraform
+### Kubernetes Persistent Volume Setup
+
+#### Important Note on HostPath Volumes
+
+In the current development environment, `HostPath` volumes are used for persistent storage. Ensure the specified paths
+exist on **all worker nodes** before deployment. Manually create the directories on each node.
+
+This setup is limited in scalability and high availability. A more scalable solution will be implemented before
+production deployment. For updates, refer to [issue #36](https://github.com/rblessings/terraform/issues/36).
+
+#### Setup Instructions
+
+1. **Copy the `setup_directories.sh` Script**
+
+   Transfer the script to each worker node using `scp`, or manually copy its contents:
+
+    ```bash
+      scp setup_directories.sh <username>@<node_ip>:/path/to/destination
+    ```
+
+2. Make the Script Executable
+
+   After transferring the script to the worker node(s), grant it executable permissions:
+
+   ```bash
+   chmod +x setup_directories.sh
+   ```
+
+3. Run the Script
+
+   Execute the script to create the necessary directories:
+
+   ```bash
+   ./setup_directories.sh
+   ```
+
+4. Verify the Directories
+
+   Finally, verify that the directories were created successfully with the correct permissions by listing their
+   contents:
+
+   ```bash
+      ls -lh /mnt/data/
+   ```
+
+---
+
+### Deploying the Application to a Kubernetes Cluster
 
 ```bash
 terraform plan -var-file="environments/dev.tfvars"
@@ -97,34 +143,6 @@ as pod status, node resource usage, and cluster health.
 - Click **Import** to finish the setup.
 
 The dashboard is now available, and you can start monitoring your Kubernetes cluster metrics.
-
-### Explore Kubernetes Cluster Metrics
-
-After importing the Kubernetes dashboard into Grafana, you can monitor critical metrics for cluster health and
-performance.
-
-#### Key Dashboard Metrics:
-
-1. **Cluster Health**:
-    - **API Server**: Request rate, error rate, latency.
-    - **Scheduler**: Scheduling latency, unscheduled pods.
-
-2. **Node Metrics**:
-    - **CPU Usage**: Per node and overall consumption.
-    - **Memory Usage**: Per node and total utilization.
-    - **Disk I/O**: Read/write operations per second.
-
-3. **Pod Health and Status**:
-    - **Pod Status**: Number of pods in various states.
-    - **Pod CPU and Memory Usage**: Resource consumption per pod.
-
-4. **Network Metrics**:
-    - **Network Throughput**: Traffic per pod and node.
-    - **Network Latency**: Latency between services.
-
-5. **Resource Requests and Limits**:
-    - **CPU Requests**: Allocated CPU for pods.
-    - **Memory Requests**: Allocated memory for pods.
 
 ---
 

--- a/deployments.tf
+++ b/deployments.tf
@@ -10,14 +10,14 @@ module "urlradar_deployment" {
   replicas       = 1
   container_port = 8080
 
-  cpu_request = "0.5" # Lowering CPU request to 0.5 CPU
-  cpu_limit   = "2"   # Lowering CPU limit to 2 CPUs
+  cpu_request = "0.5"
+  cpu_limit   = "2"
 
-  memory_request = "1Gi" # Lowering memory request to 1Gi
-  memory_limit   = "2Gi" # Lowering memory limit to 2Gi
+  memory_request = "1Gi"
+  memory_limit   = "2Gi"
 
-  # Health checks for UrlRadar: Liveness and readiness probes monitor the application’s health
-  # and ensure that dependencies (MongoDB, Kafka, Redis, etc.) are available via '/actuator/health'.
+  # Health checks for liveness and readiness probes monitor the application's health
+  # and ensure that dependencies (e.g., MongoDB, Kafka, Redis) are available.
   liveness_probe = {
     initial_delay_seconds = 90
     period_seconds        = 30
@@ -74,18 +74,19 @@ module "mongodb_statefulset" {
   container_port = 27017
 
   resource_requests = {
-    cpu    = "1"   # Lowering CPU request to 1
-    memory = "1Gi" # Lowering memory request to 1Gi
+    cpu    = "2"
+    memory = "2Gi"
   }
 
   resource_limits = {
-    cpu    = "1"   # Lowering CPU limit to 1
-    memory = "1Gi" # Lowering memory limit to 1Gi
+    cpu    = "2"
+    memory = "2Gi"
   }
 
-  # Health checks
+  # Health checks for MongoDB: Liveness and readiness probes ensure
+  # MongoDB is operational and responsive.
   liveness_probe = {
-    initial_delay_seconds = 90
+    initial_delay_seconds = 120
     period_seconds        = 30
     timeout_seconds       = 3
     exec_command = [
@@ -94,7 +95,7 @@ module "mongodb_statefulset" {
   }
 
   readiness_probe = {
-    initial_delay_seconds = 90
+    initial_delay_seconds = 120
     period_seconds        = 30
     timeout_seconds       = 3
     exec_command = [
@@ -137,16 +138,17 @@ module "kafka_statefulset" {
   container_port = 9092
 
   resource_requests = {
-    cpu    = "2"   # Lowering CPU request to 2
-    memory = "2Gi" # Lowering memory request to 2Gi
+    cpu    = "2"
+    memory = "2Gi"
   }
 
   resource_limits = {
-    cpu    = "2"   # Lowering CPU limit to 2
-    memory = "2Gi" # Lowering memory limit to 2Gi
+    cpu    = "2"
+    memory = "2Gi"
   }
 
-  # Health checks for Kafka: liveness and readiness probes ensure Kafka is running and responsive by listing topics.
+  # Health checks for Kafka: Liveness and readiness probes ensure
+  # that Kafka is running and responsive by listing topics.
   liveness_probe = {
     initial_delay_seconds = 90
     period_seconds        = 30
@@ -244,16 +246,17 @@ module "redis_statefulset" {
   container_port = 6379
 
   resource_requests = {
-    cpu    = "1"   # Lowering CPU request to 1
-    memory = "1Gi" # Lowering memory request to 1Gi
+    cpu    = "1"
+    memory = "1Gi"
   }
 
   resource_limits = {
-    cpu    = "1"   # Lowering CPU limit to 1
-    memory = "1Gi" # Lowering memory limit to 1Gi
+    cpu    = "1"
+    memory = "1Gi"
   }
 
-  # Health checks for Redis: liveness and readiness probes ensure Redis is up and responsive via 'PING' command.
+  # Health checks for Redis: Liveness and readiness probes ensure
+  # that Redis is up and responsive via the 'PING' command.
   liveness_probe = {
     initial_delay_seconds = 60
     period_seconds        = 30

--- a/environments/dev.tfvars
+++ b/environments/dev.tfvars
@@ -1,10 +1,10 @@
 # Development environment configuration
 
 # The external IP of the development environment, used to access the Kubernetes control plane and other cluster services
-external_ip = "10.119.182.110"
+external_ip = "10.101.204.68"
 
 # Kubernetes control plane host for the development cluster
-control_plane_node_host = "https://10.119.182.110:16443"
+control_plane_node_host = "https://10.101.204.68:16443"
 
 # Path to the Kubernetes configuration file for development
 kube_config_path = "~/.kube/microk8s-config"

--- a/modules/statefulset/main.tf
+++ b/modules/statefulset/main.tf
@@ -41,17 +41,6 @@ resource "kubernetes_stateful_set" "this" {
       }
 
       spec {
-        # Init container to set proper ownership and permissions on the mounted volume
-        init_container {
-          name    = "set-volume-permissions"
-          image   = "busybox"
-          command = ["/bin/sh", "-c", "chown -R 1000:1000 ${var.mount_path}"]
-          volume_mount {
-            mount_path = var.mount_path # Consistent path for mounting volume
-            name       = "${var.name}-storage"
-          }
-        }
-
         container {
           name  = var.container_name
           image = var.image

--- a/setup_directories.sh
+++ b/setup_directories.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# -----------------------------------------------------------------------------
+# Script Name: setup_directories.sh
+# Description:
+#   Automates the creation and permission setup of directories for logging and
+#   persistent storage used by Kubernetes applications like MongoDB, Prometheus,
+#   and Redis. The script:
+#     1. Creates missing directories in specified paths.
+#     2. Sets ownership to user ID 1000 and group ID 1000.
+#     3. Configures directory permissions to 755 (rwxr-xr-x).
+# -----------------------------------------------------------------------------
+
+# Define paths for the application logs and persistent storage
+DIRECTORIES=(
+  "/mnt/data/kafka-logs"
+  "/mnt/data/mongodb-logs"
+  "/mnt/data/prometheus-alertmanager"
+  "/mnt/data/redis-logs"
+)
+
+# Function to create directories and set permissions
+create_directories() {
+  for DIR in "${DIRECTORIES[@]}"; do
+    # Check if directory exists, if not, create it
+    if [ ! -d "$DIR" ]; then
+      echo "Creating directory: $DIR"
+      sudo mkdir -p "$DIR"
+    fi
+
+    # Set ownership to user ID 1000 and group ID 1000
+    echo "Setting ownership for $DIR"
+    sudo chown -R 1000:1000 "$DIR"
+
+    # Set permissions to 755 (rwxr-xr-x)
+    echo "Setting permissions for $DIR"
+    sudo chmod -R 755 "$DIR"
+  done
+}
+
+# Execute the directory creation and permission setup
+create_directories
+
+echo "Directory setup and permissions complete."


### PR DESCRIPTION
- Introduced setup_directories.sh to automate the creation and permission configuration of directories used by Kubernetes applications (e.g., MongoDB, Prometheus, Redis).
- The script:
	- Creates missing directories for logging and persistent storage.
	- Sets ownership to user ID 1000 and group ID 1000.
	- Configures directory permissions to 755 (rwxr-xr-x).
- This streamlines the setup process and ensures consistent directory structure across environments.