### PR TITLE
add prometheus scrape configuration for urlradar metrics and monitoring queries for kubernetes and spring boot.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [2024] [Ranzy Blessings]
+Copyright (c) [2025] [Ranzy Blessings]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The dashboard is now available, and you can start monitoring your metrics.
 1. **Node CPU Utilization**
     - **Query**:
       ```prometheus
-      sum by (node) (rate(container_cpu_usage_seconds_total{container="", image!="", job="kubelet"}[5m])) / sum by (node) (kube_node_status_capacity_cpu_cores{node=~".+"})
+      100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance) * 100)
       ```
     - **Description**:  
       Shows the CPU utilization as a percentage across nodes, helping identify resource bottlenecks.
@@ -150,7 +150,9 @@ The dashboard is now available, and you can start monitoring your metrics.
 1. **HTTP Response Time**
     - **Query**:
       ```prometheus
-      avg by (status) (rate(http_server_requests_seconds_sum{application="UrlRadar", status=~"2.*|5.*"}[1m])) / avg by (status) (rate(http_server_requests_seconds_count{application="UrlRadar", status=~"2.*|5.*"}[1m]))
+      avg(http_server_requests_seconds_sum{status=~"2.*|4.*|5.*"}) 
+      / 
+      avg(http_server_requests_seconds_count{status=~"2.*|4.*|5.*"})
       ```
     - **Description**:  
       Calculates the average response time for HTTP requests, showing both successful and failed requests.
@@ -158,7 +160,9 @@ The dashboard is now available, and you can start monitoring your metrics.
 2. **JVM Heap Memory Usage**
     - **Query**:
       ```prometheus
-      (jvm_memory_bytes_used{application="UrlRadar", area="heap"} / jvm_memory_bytes_max{application="UrlRadar", area="heap"}) * 100
+      100 * (avg(jvm_memory_used_bytes{area="heap"}) by (instance)) 
+      / 
+      avg(jvm_memory_max_bytes{area="heap"}) by (instance)
       ```
     - **Description**:  
       Monitors heap memory usage as a percentage of total capacity, helping detect memory pressure.

--- a/environments/dev.tfvars
+++ b/environments/dev.tfvars
@@ -1,10 +1,10 @@
 # Development environment configuration
 
 # The external IP of the development environment, used to access the Kubernetes control plane and other cluster services
-external_ip = "10.163.95.14"
+external_ip = "10.242.217.223"
 
 # Kubernetes control plane host for the development cluster
-control_plane_node_host = "https://10.163.95.14:16443"
+control_plane_node_host = "https://10.242.217.223:16443"
 
 # Path to the Kubernetes configuration file for development
 kube_config_path = "~/.kube/microk8s.config"

--- a/environments/dev.tfvars
+++ b/environments/dev.tfvars
@@ -1,10 +1,10 @@
 # Development environment configuration
 
 # The external IP of the development environment, used to access the Kubernetes control plane and other cluster services
-external_ip = "10.101.204.68"
+external_ip = "10.163.95.14"
 
 # Kubernetes control plane host for the development cluster
-control_plane_node_host = "https://10.101.204.68:16443"
+control_plane_node_host = "https://10.163.95.14:16443"
 
 # Path to the Kubernetes configuration file for development
-kube_config_path = "~/.kube/microk8s-config"
+kube_config_path = "~/.kube/microk8s.config"

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -43,11 +43,6 @@ alertmanager:
   enabled: true
 
 server:
-  service:
-    type: ClusterIP
-    port: 9090
-    nodePort: 32002
-
   persistentVolume:
     enabled: false
 


### PR DESCRIPTION
- Added extraScrapeConfigs to Prometheus configuration for scraping urlradar metrics
- Defined job 'urlradar-metrics' with target 'urlradar-svc.default.svc.cluster.local:8080'
- Metrics path set to '/actuator/prometheus' for Spring Boot 3 app monitoring

- Added Kubernetes monitoring queries to track node CPU utilization and pod restart frequency, enabling better resource and reliability insights.
  - Node CPU Utilization: Measures CPU usage percentage across nodes to identify potential bottlenecks.
  - Pod Restart Frequency: Tracks container restarts, helping to identify potential reliability issues.

- Added Spring Boot monitoring queries to monitor application performance and resource utilization.
  - HTTP Response Time: Calculates the average response time for HTTP requests, covering successful and failed requests.
  - JVM Heap Memory Usage: Monitors heap memory usage as a percentage of total capacity, helping to identify memory pressure.