### PR TITLE
chore: add github_token to prevent github api rate limits in github actions workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,5 +1,3 @@
-# TODO: Implement Slack notifications for failed builds to alert the team in the event of pipeline failures.
-
 name: Terraform Validation
 
 on:
@@ -69,6 +67,8 @@ jobs:
 
       - name: Execute TFSEC
         uses: aquasecurity/tfsec-action@v1.0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Ensure GITHUB_TOKEN is passed here for API requests
 
       # If your Kubernetes cluster is publicly accessible, you may uncomment the following steps
       # to integrate Terraform's `plan` and `apply` stages into your CI/CD pipeline.
@@ -76,10 +76,24 @@ jobs:
       # The Terraform Apply step will automatically apply the changes when pushing to the `main` branch.
       # Ensure that your cluster's access permissions and security policies allow for remote management.
 
-#      - name: Terraform Plan
-#        run: terraform plan -no-color
-#        if: github.event_name == 'pull_request'
+#        - name: Terraform Plan
+#          run: terraform plan -no-color
+#          if: github.event_name == 'pull_request'
+#
+#        - name: Terraform Apply
+#          if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+#          run: terraform apply -auto-approve
 
-#      - name: Terraform Apply
-#        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-#        run: terraform apply -auto-approve
+  # TODO: Implement Slack notifications for failed builds to alert the team in the event of pipeline failures.
+
+  # Notify Slack on failure
+#  notify-slack:
+#    if: failure()  # This job will run only if any of the above jobs fail
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Send Slack Notification
+#        run: |
+#          curl -X POST -H 'Content-type: application/json' --data "{
+#            \"text\": \"*Pipeline Failure* - Terraform Validation failed for the repository ${GITHUB_REPOSITORY}.
+#              \n\nDetails: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"
+#          }" ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Added GITHUB_TOKEN to the environment for authenticated API requests
- Ensures higher API rate limits and prevents failures due to rate limiting
- Configured GITHUB_TOKEN for actions requiring GitHub API access (e.g., tfsec)